### PR TITLE
Switched backend to double-ended priority queue for resource requests

### DIFF
--- a/bin/glb-run
+++ b/bin/glb-run
@@ -10,6 +10,8 @@ import logging
 
 from rich.logging import RichHandler
 
+from glb.utils.utils import find_gpu_master_address, is_server_available
+
 
 log = logging.getLogger(__file__)
 LOGGING_FORMAT = '%(message)s'
@@ -17,9 +19,10 @@ LOGGING_FORMAT = '%(message)s'
 
 def run():
     parser = ArgumentParser()
+    parser.add_argument('--debug', action='store_true')
     parser.add_argument('cmds', type=str, nargs='+')
     args = parser.parse_args()
-
+ 
     logging.basicConfig(
         level=logging.WARNING,
         format=LOGGING_FORMAT, 
@@ -27,11 +30,26 @@ def run():
             locals_max_string=None, 
             tracebacks_word_wrap=False)])
 
-    proc = subprocess.Popen(['glb-start'])
-    time.sleep(0.5)
+    glb_cmd = ['glb-start']
+    if args.debug:
+        glb_cmd.append('--debug')
+    proc = subprocess.Popen(glb_cmd)
+
+    # Wait for the server to start.
+    # TODO: Implement a timeout?
+    while True:
+        try:
+            if not is_server_available(find_gpu_master_address()):
+                continue
+        except FileNotFoundError:
+            time.sleep(0.5)
+        else:
+            break
+
     procs = [subprocess.Popen(cmd.split(' ')) for cmd in args.cmds]
     for p in procs:
         p.wait()
+
     proc.terminate()
 
 if __name__ == '__main__':

--- a/examples/mnist/download_mnist.py
+++ b/examples/mnist/download_mnist.py
@@ -1,0 +1,20 @@
+import argparse
+
+import tensorflow as tf
+import torchvision as tv
+
+
+def download_tf():
+    tf.keras.datasets.mnist.load_data()
+
+def download_torch():
+    tv.datasets.MNIST(root='./', download=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_dir', type=str, default='./')
+    args = parser.parse_args()
+
+    download_tf()
+    download_torch()

--- a/examples/mnist/mnist_doit.py
+++ b/examples/mnist/mnist_doit.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from doit.task import clean_targets
 
 
+MNIST_FILES = ['/root/.keras/datasets/mnist.npz', './MNIST/raw/train-images-idx3-ubyte']
+
+
 def clean_glob_paths(paths: list):
     for path in paths:
         p = Path(path)
@@ -13,14 +16,24 @@ def clean_glob_paths(paths: list):
             item.unlink()
 
 
+def task_download_mnist():
+    return {
+        'doc': 'Download torchvision and keras versions of MNIST.',
+        'file_dep': [],
+        'targets': MNIST_FILES,
+        'actions': [['python', 'download_mnist.py']],
+        'clean': [clean_targets],
+    }
+
+
 """
 Tensorflow
 """
 def task_0():
     return {
         'doc': 'Tensorflow MNIST training 0',
-        'file_dep': [ ],
-        'targets': [ ],
+        'file_dep': MNIST_FILES,
+        'targets': [],
         'actions': [['python', 'tf_mnist_train.py']],
         'clean': [clean_targets],
     }
@@ -29,7 +42,7 @@ def task_0():
 def task_1():
     return {
         'doc': 'Tensorflow MNIST training 1',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'tf_mnist_train.py']],
         'clean': [clean_targets],
@@ -39,7 +52,7 @@ def task_1():
 def task_2():
     return {
         'doc': 'Tensorflow MNIST training 2',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'tf_mnist_train.py']],
         'clean': [clean_targets],
@@ -52,7 +65,7 @@ PyTorch
 def task_3():
     return {
         'doc': 'PyTorch MNIST training 0',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'torch_mnist_train.py']],
         'clean': [clean_targets],
@@ -62,7 +75,7 @@ def task_3():
 def task_4():
     return {
         'doc': 'PyTorch MNIST training 1',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'torch_mnist_train.py']],
         'clean': [clean_targets],
@@ -72,7 +85,7 @@ def task_4():
 def task_5():
     return {
         'doc': 'PyTorch MNIST training 2',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'torch_mnist_train.py']],
         'clean': [clean_targets],
@@ -85,7 +98,7 @@ JAX
 def task_6():
     return {
         'doc': 'JAX FLAX MNIST training 0',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'jax_mnist_train.py']],
         'clean': [clean_targets],
@@ -95,7 +108,7 @@ def task_6():
 def task_7():
     return {
         'doc': 'JAX FLAX MNIST training 1',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'jax_mnist_train.py']],
         'clean': [clean_targets],
@@ -105,7 +118,7 @@ def task_7():
 def task_8():
     return {
         'doc': 'JAX FLAX MNIST training 2',
-        'file_dep': [ ],
+        'file_dep': MNIST_FILES,
         'targets': [ ],
         'actions': [['python', 'jax_mnist_train.py']],
         'clean': [clean_targets],

--- a/glb/core/constants.py
+++ b/glb/core/constants.py
@@ -1,13 +1,18 @@
 import pathlib
+import tempfile
 from enum import Enum, auto
 
-__all__ = ['GLB_SERVER_TMP_INFO_PATH', 'ServiceErrorCodes']
+__all__ = ['GLB_SERVER_TMP_INFO_PATH', 'ServiceErrorCode']
 
 
 # Obtain a universally consistent location to cache intermediate info needed by clients.
-GLB_SERVER_TMP_INFO_PATH = str( pathlib.Path(__file__).resolve().parent / '.glb.conf' )
+GLB_SERVER_TMP_INFO_PATH = pathlib.Path(tempfile.gettempdir()) / '.glb.conf'
 
-class ServiceErrorCodes(Enum):
+class ResourcePolicy(Enum):
+    SPREAD = auto()
+    PACK = auto()
+
+class ServiceErrorCode(Enum):
     OK = auto()
     EXCEEDS_TOTAL_MEMORY = auto()
     EXCEEDS_CURRENT_MEMORY = auto()

--- a/glb/core/globals.py
+++ b/glb/core/globals.py
@@ -1,3 +1,5 @@
+import depq
+
 from threading import Lock, Event
 from typing import Dict, List, Tuple, Union, Optional
 NumericType = Union[int, float]
@@ -10,11 +12,11 @@ class GPUStates:
     STATES: Dict[int, Dict[str, NumericType]] = dict()
     STATES_INIT = Event()
     LOCK = Lock()
-    HEAP: List[Tuple[float, int]] = []
+    GPU_QUEUE: depq.DEPQ = depq.DEPQ()
     PROFILING_GROUP: Dict[int, str] = dict()
 
     # TODO: This should probably be defined in constants.py
-    RESOURCE_POLICY: str = 'memoryUsed'
+    TARGET_RESOURCE: str = 'memoryUsed'
 
 
 class JobStates:

--- a/glb/grpc_resources/master.proto
+++ b/glb/grpc_resources/master.proto
@@ -10,7 +10,10 @@ message Empty { }
 
 message BoolResponse { bool response = 1; }
 
-message JobType { string jobstr = 1; }
+message JobType { 
+    string jobstr = 1; 
+    int32 resource_policy = 2;
+}
 
 message GPU {
     int32 gpu_id = 1;

--- a/glb/grpc_resources/master_pb2.py
+++ b/glb/grpc_resources/master_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0cmaster.proto\"\x07\n\x05\x45mpty\" \n\x0c\x42oolResponse\x12\x10\n\x08response\x18\x01 \x01(\x08\"\x19\n\x07JobType\x12\x0e\n\x06jobstr\x18\x01 \x01(\t\"(\n\x03GPU\x12\x0e\n\x06gpu_id\x18\x01 \x01(\x05\x12\x11\n\terrorcode\x18\x02 \x01(\x05\"\x80\x01\n\nJobProfile\x12\x19\n\x07jobtype\x18\x01 \x01(\x0b\x32\x08.JobType\x12\x11\n\x03gpu\x18\x02 \x01(\x0b\x32\x04.GPU\x12\x11\n\tsucceeded\x18\x03 \x01(\x08\x12\x1b\n\x13max_gpu_memory_used\x18\x04 \x01(\x03\x12\x14\n\x0cmax_gpu_load\x18\x05 \x01(\x03\x32}\n\tGPUMaster\x12\x1e\n\nRequestGPU\x12\x08.JobType\x1a\x04.GPU\"\x00\x12$\n\x0b\x43ompleteJob\x12\x0b.JobProfile\x1a\x06.Empty\"\x00\x12*\n\rJobTypeExists\x12\x08.JobType\x1a\r.BoolResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0cmaster.proto\"\x07\n\x05\x45mpty\" \n\x0c\x42oolResponse\x12\x10\n\x08response\x18\x01 \x01(\x08\"2\n\x07JobType\x12\x0e\n\x06jobstr\x18\x01 \x01(\t\x12\x17\n\x0fresource_policy\x18\x02 \x01(\x05\"(\n\x03GPU\x12\x0e\n\x06gpu_id\x18\x01 \x01(\x05\x12\x11\n\terrorcode\x18\x02 \x01(\x05\"\x80\x01\n\nJobProfile\x12\x19\n\x07jobtype\x18\x01 \x01(\x0b\x32\x08.JobType\x12\x11\n\x03gpu\x18\x02 \x01(\x0b\x32\x04.GPU\x12\x11\n\tsucceeded\x18\x03 \x01(\x08\x12\x1b\n\x13max_gpu_memory_used\x18\x04 \x01(\x03\x12\x14\n\x0cmax_gpu_load\x18\x05 \x01(\x03\x32}\n\tGPUMaster\x12\x1e\n\nRequestGPU\x12\x08.JobType\x1a\x04.GPU\"\x00\x12$\n\x0b\x43ompleteJob\x12\x0b.JobProfile\x1a\x06.Empty\"\x00\x12*\n\rJobTypeExists\x12\x08.JobType\x1a\r.BoolResponse\"\x00\x62\x06proto3'
 )
 
 
@@ -97,6 +97,13 @@ _JOBTYPE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='resource_policy', full_name='JobType.resource_policy', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -110,7 +117,7 @@ _JOBTYPE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=59,
-  serialized_end=84,
+  serialized_end=109,
 )
 
 
@@ -148,8 +155,8 @@ _GPU = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=86,
-  serialized_end=126,
+  serialized_start=111,
+  serialized_end=151,
 )
 
 
@@ -208,8 +215,8 @@ _JOBPROFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=129,
-  serialized_end=257,
+  serialized_start=154,
+  serialized_end=282,
 )
 
 _JOBPROFILE.fields_by_name['jobtype'].message_type = _JOBTYPE
@@ -265,8 +272,8 @@ _GPUMASTER = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=259,
-  serialized_end=384,
+  serialized_start=284,
+  serialized_end=409,
   methods=[
   _descriptor.MethodDescriptor(
     name='RequestGPU',

--- a/glb/utils/gpu_monitors.py
+++ b/glb/utils/gpu_monitors.py
@@ -54,17 +54,20 @@ class GPUMonitor(Thread):
         # The lock is probably necessary here because of the sequence of appends.
         # We don't want to get interrupted by the server trying to heappop a gpu.
         with GPUStates.LOCK:
-            GPUStates.HEAP.clear()
+            gpu_list = []
             for gid in states:
                 # If there is a drop in the policy resource, trigger threads to 
                 # check again for available resources for their waiting jobs.
                 if gid in GPUStates.STATES:
-                    if GPUStates.STATES[gid][GPUStates.RESOURCE_POLICY] > states[gid][GPUStates.RESOURCE_POLICY]:
+                    if GPUStates.STATES[gid][GPUStates.TARGET_RESOURCE] > states[gid][GPUStates.TARGET_RESOURCE]:
                         JobStates.READY.set()
 
                 GPUStates.STATES[gid] = states[gid]
-                GPUStates.HEAP.append( (states[gid][GPUStates.RESOURCE_POLICY], gid) )
-            heapq.heapify(GPUStates.HEAP)
+                gpu_list.append( (gid, states[gid][GPUStates.TARGET_RESOURCE]) )
+
+            # Heapify at the end to for O(n) instead of O(n log n).
+            GPUStates.GPU_QUEUE.clear()
+            GPUStates.GPU_QUEUE.extend(gpu_list)
 
         GPUStates.STATES_INIT.set()
 

--- a/glb/utils/utils.py
+++ b/glb/utils/utils.py
@@ -1,4 +1,8 @@
+import os
+
 import grpc
+
+from glb.core.constants import GLB_SERVER_TMP_INFO_PATH
 
 
 __all__ = ['find_free_port', 'is_server_available']
@@ -20,3 +24,14 @@ def is_server_available(address: str = 'localhost:50051') -> bool:
     except grpc.FutureTimeoutError:
         return False
     return True
+
+
+def find_gpu_master_address() -> str:
+    # Find the GPU Master port
+    if os.path.isfile(GLB_SERVER_TMP_INFO_PATH):
+        with open(GLB_SERVER_TMP_INFO_PATH, 'r') as glb_file:
+            gpu_master_addr = f'localhost:{glb_file.read()}'
+    # File containing current server port must exist.
+    else:
+        raise FileNotFoundError(f'{GLB_SERVER_TMP_INFO_PATH}, serve never called.')
+    return gpu_master_addr

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ install_requires = [
     'nvidia-ml-py3',
     'grpcio',
     'grpcio-tools',
+    'depq',
     'rich',
 ]
 

--- a/tests/many_small_jobs/job_pack.py
+++ b/tests/many_small_jobs/job_pack.py
@@ -1,0 +1,9 @@
+import glb
+
+@glb.job(resource_policy='pack')
+def job(mem: int) -> None:
+    import torch
+    x = torch.randn(int(mem * 8e6 // 32), device='cuda:0')
+
+if __name__ == '__main__':
+    job(100)

--- a/tests/many_small_jobs/job_spread.py
+++ b/tests/many_small_jobs/job_spread.py
@@ -1,0 +1,9 @@
+import glb
+
+@glb.job(resource_policy='spread')
+def job(mem: int) -> None:
+    import torch
+    x = torch.randn(int(mem * 8e6 // 32), device='cuda:0')
+
+if __name__ == '__main__':
+    job(100)

--- a/tests/many_small_jobs/run.sh
+++ b/tests/many_small_jobs/run.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+(
+    cd $PARENT_PATH
+
+    NUM_JOBS=$1
+    PROCS=()
+    for (( i = 0; i < $NUM_JOBS; ++i )); do
+        python job_pack.py &
+        PROCS+=($!)
+
+        python job_spread.py &
+        PROCS+=($!)
+    done
+
+    for proc in ${PROCS[@]}; do
+        wait $proc
+    done
+)

--- a/tests/many_small_jobs/run_pack.sh
+++ b/tests/many_small_jobs/run_pack.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+(
+    cd $PARENT_PATH
+
+    NUM_JOBS=$1
+    PROCS=()
+    for (( i = 0; i < $NUM_JOBS; ++i )); do
+        python job_pack.py &
+        PROCS+=($!)
+    done
+
+    for proc in ${PROCS[@]}; do
+        wait $proc
+    done
+)

--- a/tests/many_small_jobs/run_spread.sh
+++ b/tests/many_small_jobs/run_spread.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+(
+    cd $PARENT_PATH
+
+    NUM_JOBS=$1
+    PROCS=()
+    for (( i = 0; i < $NUM_JOBS; ++i )); do
+        python job_spread.py &
+        PROCS+=($!)
+    done
+
+    for proc in ${PROCS[@]}; do
+        wait $proc
+    done
+)


### PR DESCRIPTION
This allows multiple resource allocation policies: packing or spreading across GPUs. Each job can specify its own resource policy. 

Changed temporary port file to write in platform agnostic tmp directory rather than glb/core.