### PR TITLE
Bugfix: client-side profiler now monitors only its parent process.

### DIFF
--- a/glb/core/gpu_master.py
+++ b/glb/core/gpu_master.py
@@ -15,10 +15,10 @@ TODO (BACKLOG):
 """
 import sys
 import os
-import time
+# import time
 from concurrent import futures
-import threading
-from threading import Thread
+# import threading
+# from threading import Thread
 import signal
 import logging
 
@@ -40,26 +40,26 @@ log = logging.getLogger(__file__)
 __all__ = ['serve']
 
 
-class BackgroundEventTrigger(Thread):
-    """
-    """
-    def __init__(self, event: threading.Event, delay=5):
-        super().__init__()
-        self.event = event
-        self.stopped = False
-        self.delay = delay
-        self.start()
+# class BackgroundEventTrigger(Thread):
+#     """
+#     """
+#     def __init__(self, event: threading.Event, delay=5):
+#         super().__init__()
+#         self.event = event
+#         self.stopped = False
+#         self.delay = delay
+#         self.start()
 
-    def run(self):
-        while not self.stopped:
-            time.sleep(self.delay)
-            self.event.set()
+#     def run(self):
+#         while not self.stopped:
+#             time.sleep(self.delay)
+#             self.event.set()
 
-    def __enter__(self):
-        return self
+#     def __enter__(self):
+#         return self
 
-    def __exit__(self, type, value, traceback):
-        self.stopped = True
+#     def __exit__(self, type, value, traceback):
+#         self.stopped = True
 
 
 def get_next_available_gpu(jobstr: str, resource_policy: ResourcePolicy) -> protos.GPU:

--- a/glb/grpc_resources/master.proto
+++ b/glb/grpc_resources/master.proto
@@ -25,5 +25,4 @@ message JobProfile {
     GPU gpu = 2;
     bool succeeded = 3;
     int64 max_gpu_memory_used = 4;
-    int64 max_gpu_load = 5;
 }

--- a/glb/grpc_resources/master_pb2.py
+++ b/glb/grpc_resources/master_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0cmaster.proto\"\x07\n\x05\x45mpty\" \n\x0c\x42oolResponse\x12\x10\n\x08response\x18\x01 \x01(\x08\"2\n\x07JobType\x12\x0e\n\x06jobstr\x18\x01 \x01(\t\x12\x17\n\x0fresource_policy\x18\x02 \x01(\x05\"(\n\x03GPU\x12\x0e\n\x06gpu_id\x18\x01 \x01(\x05\x12\x11\n\terrorcode\x18\x02 \x01(\x05\"\x80\x01\n\nJobProfile\x12\x19\n\x07jobtype\x18\x01 \x01(\x0b\x32\x08.JobType\x12\x11\n\x03gpu\x18\x02 \x01(\x0b\x32\x04.GPU\x12\x11\n\tsucceeded\x18\x03 \x01(\x08\x12\x1b\n\x13max_gpu_memory_used\x18\x04 \x01(\x03\x12\x14\n\x0cmax_gpu_load\x18\x05 \x01(\x03\x32}\n\tGPUMaster\x12\x1e\n\nRequestGPU\x12\x08.JobType\x1a\x04.GPU\"\x00\x12$\n\x0b\x43ompleteJob\x12\x0b.JobProfile\x1a\x06.Empty\"\x00\x12*\n\rJobTypeExists\x12\x08.JobType\x1a\r.BoolResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0cmaster.proto\"\x07\n\x05\x45mpty\" \n\x0c\x42oolResponse\x12\x10\n\x08response\x18\x01 \x01(\x08\"2\n\x07JobType\x12\x0e\n\x06jobstr\x18\x01 \x01(\t\x12\x17\n\x0fresource_policy\x18\x02 \x01(\x05\"(\n\x03GPU\x12\x0e\n\x06gpu_id\x18\x01 \x01(\x05\x12\x11\n\terrorcode\x18\x02 \x01(\x05\"j\n\nJobProfile\x12\x19\n\x07jobtype\x18\x01 \x01(\x0b\x32\x08.JobType\x12\x11\n\x03gpu\x18\x02 \x01(\x0b\x32\x04.GPU\x12\x11\n\tsucceeded\x18\x03 \x01(\x08\x12\x1b\n\x13max_gpu_memory_used\x18\x04 \x01(\x03\x32}\n\tGPUMaster\x12\x1e\n\nRequestGPU\x12\x08.JobType\x1a\x04.GPU\"\x00\x12$\n\x0b\x43ompleteJob\x12\x0b.JobProfile\x1a\x06.Empty\"\x00\x12*\n\rJobTypeExists\x12\x08.JobType\x1a\r.BoolResponse\"\x00\x62\x06proto3'
 )
 
 
@@ -196,13 +196,6 @@ _JOBPROFILE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='max_gpu_load', full_name='JobProfile.max_gpu_load', index=4,
-      number=5, type=3, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -215,8 +208,8 @@ _JOBPROFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=154,
-  serialized_end=282,
+  serialized_start=153,
+  serialized_end=259,
 )
 
 _JOBPROFILE.fields_by_name['jobtype'].message_type = _JOBTYPE
@@ -272,8 +265,8 @@ _GPUMASTER = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=284,
-  serialized_end=409,
+  serialized_start=261,
+  serialized_end=386,
   methods=[
   _descriptor.MethodDescriptor(
     name='RequestGPU',

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,26 @@ from setuptools import setup, find_packages
 install_requires = [
     'nvidia-ml-py3',
     'grpcio',
-    'grpcio-tools',
     'depq',
     'rich',
+]
+
+dev_requires = [
+    'grpcio-tools',
 ]
 
 setup(
     name='gpu-load-balancer',
     packages=find_packages(),
-    version='0.2.1',
+    version='0.2.2',
     license='unlicense',
     description='GPU Load Balancer (GLB). Map N jobs to M devices on the same machine.',
     author='Jonathan Helland',
     url='https://github.com/j-helland/glb',
-    download_url='https://github.com/j-helland/glb/archive/refs/tags/pre-v-0.2.1.tar.gz',
+    download_url='https://github.com/j-helland/glb/archive/refs/tags/pre-v-0.2.2.tar.gz',
     keywords=['GPU', 'load balancing'],
     install_requires=install_requires,
+    extras_require={ 'dev': dev_requires },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Beforehand, the client gpu profiler would look at total resource consumption for the target GPU, which led to overestimation of resource consumption for particular processes. Now, the client-side profiler will only extract resource consumption for the PID of the process that runs it.

This resolves Issue #5.